### PR TITLE
add purchase actions for droplet upgrades

### DIFF
--- a/main.js
+++ b/main.js
@@ -423,6 +423,7 @@ function startServer(port, host) {
         if (typeof body.name === 'string') updated.name = body.name;
         if (typeof body.token === 'string') updated.token = body.token;
         if (body.pixelRight != null) updated.pixelRight = body.pixelRight;
+        if (body.droplets != null) updated.droplets = body.droplets;
         if (typeof body.active === 'boolean') updated.active = body.active;
         accounts[idx] = updated;
         writeJson(ACCOUNTS_FILE, accounts);
@@ -470,7 +471,7 @@ function startServer(port, host) {
           return;
         }
         const accounts = readJson(ACCOUNTS_FILE, []);
-        const account = { id: Date.now(), name, token, pixelCount: null, pixelMax: null, active: false };
+        const account = { id: Date.now(), name, token, pixelCount: null, pixelMax: null, droplets: null, active: false };
         
         const settings = readJson(SETTINGS_FILE, { cf_clearance: '' });
         if (settings.cf_clearance && settings.cf_clearance.length >= 30) {
@@ -481,6 +482,7 @@ function startServer(port, host) {
               account.pixelMax = Number(me.charges.max);
               account.active = true;
             }
+            if (me && me.droplets != null) account.droplets = Number(me.droplets);
             if (me && me.name && !name) account.name = String(me.name);
           } catch {}
         }
@@ -523,9 +525,10 @@ function startServer(port, host) {
           } : null
         });
         if (me && me.charges) {
-          
+
           acct.pixelCount = Math.floor(Number(me.charges.count));
           acct.pixelMax = Math.floor(Number(me.charges.max));
+          if (me.droplets != null) acct.droplets = Math.floor(Number(me.droplets));
           acct.active = true;
         } else {
           acct.active = false;

--- a/public/i18n/cn.json
+++ b/public/i18n/cn.json
@@ -71,6 +71,8 @@
     "saveSettings": "保存",
     "edit": "编辑",
     "checkPixels": "检查像素",
+    "buyMaxCharges": "+5 最大充能 / 500 droplets",
+    "buyPaintCharges": "+30 上色充能 / 500 droplets",
     "delete": "删除"
   },
   "thumb": {
@@ -107,6 +109,8 @@
     "imageLoadFailed": "图片加载失败，请检查数值。",
     "tokenAlreadyExists": "已存在使用该令牌的账户。",
     "cfCannotBeClearedWithAccounts": "存在账户时，cf_clearance 不能为空。",
-    "cfClearanceChange": "请更改 cf_clearance。"
+    "cfClearanceChange": "请更改 cf_clearance。",
+    "purchaseFailed": "购买失败（droplets 不足？）",
+    "purchaseSuccess": "购买成功。"
   }
 }

--- a/public/i18n/cn.json
+++ b/public/i18n/cn.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "账户名称",
     "accountToken": "账户令牌",
+    "droplets": "Droplets",
     "pixelRight": "像素上限",
     "status": "状态",
     "actions": "操作",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Kontoname",
     "accountToken": "Konto-Token",
+    "droplets": "Droplets",
     "pixelRight": "Pixellimit",
     "status": "Status",
     "actions": "Aktion",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -71,6 +71,8 @@
     "saveSettings": "Speichern",
     "edit": "Bearbeiten",
     "checkPixels": "Pixel prüfen",
+    "buyMaxCharges": "+5 maximale Ladungen / 500 droplets",
+    "buyPaintCharges": "+30 Mal-Ladungen / 500 droplets",
     "delete": "Löschen"
   },
   "thumb": {
@@ -107,7 +109,9 @@
     "imageLoadFailed": "Bild konnte nicht geladen werden. Werte prüfen.",
     "tokenAlreadyExists": "Ein Konto mit diesem Token existiert bereits.",
     "cfCannotBeClearedWithAccounts": "cf_clearance darf bei vorhandenen Konten nicht leer sein.",
-    "cfClearanceChange": "Bitte cf_clearance ändern."
+    "cfClearanceChange": "Bitte cf_clearance ändern.",
+    "purchaseFailed": "Kauf fehlgeschlagen (nicht genug droplets?)",
+    "purchaseSuccess": "Kauf erfolgreich."
   }
 }
 

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -71,6 +71,8 @@
     "saveSettings": "Save",
     "edit": "Edit",
     "checkPixels": "Check pixel",
+    "buyMaxCharges": "+5 max charges / 500 droplets",
+    "buyPaintCharges": "+30 paint charges / 500 droplets",
     "delete": "Delete"
   },
   "thumb": {
@@ -107,7 +109,9 @@
     "imageLoadFailed": "Image could not be loaded. Check the values.",
     "tokenAlreadyExists": "An account with this token already exists.",
     "cfCannotBeClearedWithAccounts": "cf_clearance cannot be left empty while accounts exist.",
-    "cfClearanceChange": "Please change cf_clearance."
+    "cfClearanceChange": "Please change cf_clearance.",
+    "purchaseFailed": "Purchase failed (not enough droplets?)",
+    "purchaseSuccess": "Purchase successful."
   }
 }
 

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Account name",
     "accountToken": "Account token",
+    "droplets": "Droplets",
     "pixelRight": "Pixel limit",
     "status": "Status",
     "actions": "Action",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Nombre de la cuenta",
     "accountToken": "Token de la cuenta",
+    "droplets": "Droplets",
     "pixelRight": "Límite de píxeles",
     "status": "Estado",
     "actions": "Acción",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -71,6 +71,8 @@
     "saveSettings": "Guardar",
     "edit": "Editar",
     "checkPixels": "Comprobar píxeles",
+    "buyMaxCharges": "+5 cargas máximas / 500 droplets",
+    "buyPaintCharges": "+30 cargas de pintura / 500 droplets",
     "delete": "Eliminar"
   },
   "thumb": {
@@ -107,7 +109,9 @@
     "imageLoadFailed": "No se pudo cargar la imagen. Revisa los valores.",
     "tokenAlreadyExists": "Ya existe una cuenta con este token.",
     "cfCannotBeClearedWithAccounts": "cf_clearance no puede quedar vacío mientras haya cuentas.",
-    "cfClearanceChange": "Cambia el valor de cf_clearance."
+    "cfClearanceChange": "Cambia el valor de cf_clearance.",
+    "purchaseFailed": "Compra fallida (¿no hay suficientes droplets?)",
+    "purchaseSuccess": "Compra realizada."
   }
 }
 

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -71,6 +71,8 @@
     "saveSettings": "Enregistrer",
     "edit": "Modifier",
     "checkPixels": "Vérifier les pixels",
+    "buyMaxCharges": "+5 charges max / 500 droplets",
+    "buyPaintCharges": "+30 charges de peinture / 500 droplets",
     "delete": "Supprimer"
   },
   "thumb": {
@@ -107,7 +109,9 @@
     "imageLoadFailed": "L’image n’a pas pu être chargée. Vérifiez les valeurs.",
     "tokenAlreadyExists": "Un compte avec ce jeton existe déjà.",
     "cfCannotBeClearedWithAccounts": "cf_clearance ne peut pas être vide tant que des comptes existent.",
-    "cfClearanceChange": "Veuillez modifier cf_clearance."
+    "cfClearanceChange": "Veuillez modifier cf_clearance.",
+    "purchaseFailed": "Achat échoué (pas assez de droplets ?)",
+    "purchaseSuccess": "Achat réussi."
   }
 }
 

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Nom du compte",
     "accountToken": "Jeton du compte",
+    "droplets": "Droplets",
     "pixelRight": "Limite de pixels",
     "status": "Statut",
     "actions": "Action",

--- a/public/i18n/ja.json
+++ b/public/i18n/ja.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "アカウント名",
     "accountToken": "アカウントトークン",
+    "droplets": "Droplets",
     "pixelRight": "ピクセル上限",
     "status": "ステータス",
     "actions": "操作",

--- a/public/i18n/ja.json
+++ b/public/i18n/ja.json
@@ -71,6 +71,8 @@
     "saveSettings": "保存",
     "edit": "編集",
     "checkPixels": "ピクセル確認",
+    "buyMaxCharges": "+5 最大チャージ / 500 droplets",
+    "buyPaintCharges": "+30 ペイントチャージ / 500 droplets",
     "delete": "削除"
   },
   "thumb": {
@@ -107,7 +109,9 @@
     "imageLoadFailed": "画像を読み込めませんでした。値を確認してください。",
     "tokenAlreadyExists": "このトークンのアカウントは既に存在します。",
     "cfCannotBeClearedWithAccounts": "アカウントがある場合、cf_clearance を空にはできません。",
-    "cfClearanceChange": "cf_clearance を変更してください。"
+    "cfClearanceChange": "cf_clearance を変更してください。",
+    "purchaseFailed": "購入に失敗しました（ドロップレットが不足しています？）",
+    "purchaseSuccess": "購入に成功しました。"
   }
 }
 

--- a/public/i18n/ru.json
+++ b/public/i18n/ru.json
@@ -71,6 +71,8 @@
     "saveSettings": "Сохранить",
     "edit": "Редактировать",
     "checkPixels": "Проверить пиксели",
+    "buyMaxCharges": "+5 макс зарядов / 500 droplets",
+    "buyPaintCharges": "+30 зарядов краски / 500 droplets",
     "delete": "Удалить"
   },
   "thumb": {
@@ -107,7 +109,9 @@
     "imageLoadFailed": "Не удалось загрузить изображение. Проверьте значения.",
     "tokenAlreadyExists": "Аккаунт с этим токеном уже существует.",
     "cfCannotBeClearedWithAccounts": "cf_clearance не может быть пустым при наличии аккаунтов.",
-    "cfClearanceChange": "Пожалуйста, измените cf_clearance."
+    "cfClearanceChange": "Пожалуйста, измените cf_clearance.",
+    "purchaseFailed": "Покупка не удалась (недостаточно droplets?)",
+    "purchaseSuccess": "Покупка успешна."
   }
 }
 

--- a/public/i18n/ru.json
+++ b/public/i18n/ru.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Имя аккаунта",
     "accountToken": "Токен аккаунта",
+    "droplets": "Droplets",
     "pixelRight": "Лимит пикселей",
     "status": "Статус",
     "actions": "Действие",

--- a/public/i18n/tr.json
+++ b/public/i18n/tr.json
@@ -71,6 +71,8 @@
     "saveSettings": "Kaydet",
     "edit": "Düzenle",
     "checkPixels": "Piksel kontrol et",
+    "buyMaxCharges": "+5 max hak / 500 droplets",
+    "buyPaintCharges": "+30 boya hakkı / 500 droplets",
     "delete": "Sil"
   },
   "thumb": {
@@ -107,7 +109,9 @@
     "imageLoadFailed": "Resim yüklenemedi. Değerleri kontrol edin.",
     "tokenAlreadyExists": "Bu token ile daha önce hesap kaydedildi.",
     "cfCannotBeClearedWithAccounts": "Hesap varken cf_clearance boş bırakılamaz.",
-    "cfClearanceChange": "Lütfen cf_clearance değiştirin."
+    "cfClearanceChange": "Lütfen cf_clearance değiştirin.",
+    "purchaseFailed": "Satın alma başarısız (yeterli droplets yok mu?)",
+    "purchaseSuccess": "Satın alma başarılı."
   }
 }
 

--- a/public/i18n/tr.json
+++ b/public/i18n/tr.json
@@ -34,6 +34,7 @@
   "table": {
     "accountName": "Hesap ismi",
     "accountToken": "Hesap Tokeni",
+    "droplets": "Droplets",
     "pixelRight": "Piksel Hakkı",
     "status": "Durum",
     "actions": "İşlem",

--- a/public/index.html
+++ b/public/index.html
@@ -389,8 +389,8 @@
     }
     .modal-card .form-grid label { font-size: 14px; align-self: center; }
     .modal-card .form-grid input { width: 100%; }
-    .table-actions { display: flex; flex-direction: column; gap: 6px; }
-    .table-actions-row { display: flex; gap: 6px; }
+    .table-actions { display: flex; flex-direction: column; gap: 6px; max-width: 260px; }
+    .table-actions-row { display: flex; gap: 6px; flex-wrap: wrap; }
     
     #app-toast-container { position: fixed; top: 16px; right: 16px; display: flex; flex-direction: column; gap: 10px; z-index: 2000; pointer-events: none; }
     .app-toast { pointer-events: auto; min-width: 260px; max-width: 380px; padding: 10px 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,0.15); box-shadow: 0 8px 30px rgba(0,0,0,0.35); backdrop-filter: blur(6px); color: #fff; display: flex; align-items: center; gap: 10px; animation: toast-in 200ms ease-out; }
@@ -3125,6 +3125,8 @@
         actionsWrap.className = 'table-actions';
         const rowTop = document.createElement('div');
         rowTop.className = 'table-actions-row';
+        const rowMid = document.createElement('div');
+        rowMid.className = 'table-actions-row';
         const rowBottom = document.createElement('div');
         rowBottom.className = 'table-actions-row';
         const editBtn = document.createElement('button');
@@ -3142,9 +3144,50 @@
           try {
             const res = await fetch('/api/accounts/' + row.id + '/refresh', { method: 'POST' });
             if (!res.ok) return;
-            const updated = await res.json();
             await loadAccounts();
           } catch {}
+        });
+        const buyMaxBtn = document.createElement('button');
+        buyMaxBtn.type = 'button';
+        buyMaxBtn.className = 'app-btn';
+        buyMaxBtn.textContent = t('buttons.buyMaxCharges');
+        buyMaxBtn.addEventListener('click', async () => {
+          try {
+            const res = await fetch('/api/accounts/' + row.id + '/purchase', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ productId: 70 })
+            });
+            if (res.ok) {
+              await refreshAccountById(row.id);
+              showToast(t('messages.purchaseSuccess'), 'success');
+            } else {
+              showToast(t('messages.purchaseFailed'));
+            }
+          } catch {
+            showToast(t('messages.purchaseFailed'));
+          }
+        });
+        const buyPaintBtn = document.createElement('button');
+        buyPaintBtn.type = 'button';
+        buyPaintBtn.className = 'app-btn';
+        buyPaintBtn.textContent = t('buttons.buyPaintCharges');
+        buyPaintBtn.addEventListener('click', async () => {
+          try {
+            const res = await fetch('/api/accounts/' + row.id + '/purchase', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ productId: 80 })
+            });
+            if (res.ok) {
+              await refreshAccountById(row.id);
+              showToast(t('messages.purchaseSuccess'), 'success');
+            } else {
+              showToast(t('messages.purchaseFailed'));
+            }
+          } catch {
+            showToast(t('messages.purchaseFailed'));
+          }
         });
         const delBtn = document.createElement('button');
         delBtn.type = 'button';
@@ -3158,8 +3201,11 @@
         });
         rowTop.appendChild(editBtn);
         rowTop.appendChild(delBtn);
-        rowBottom.appendChild(checkBtn);
+        rowMid.appendChild(checkBtn);
+        rowMid.appendChild(buyMaxBtn);
+        rowBottom.appendChild(buyPaintBtn);
         actionsWrap.appendChild(rowTop);
+        actionsWrap.appendChild(rowMid);
         actionsWrap.appendChild(rowBottom);
         tdActions.appendChild(actionsWrap);
         tr.appendChild(tdName);

--- a/public/index.html
+++ b/public/index.html
@@ -644,6 +644,7 @@
                 <tr>
                   <th data-i18n="table.accountName">Hesap ismi</th>
                   <th data-i18n="table.accountToken">Hesap Tokeni</th>
+                  <th data-i18n="table.droplets">Droplets</th>
                   <th data-i18n="table.pixelRight">Piksel Hakkı</th>
                   <th data-i18n="table.status">Durum</th>
                   <th data-i18n="table.actions">İşlem</th>
@@ -3106,6 +3107,10 @@
         const shortToken = fullToken.length > 30 ? (fullToken.slice(0, 30) + '…') : fullToken;
         tdToken.textContent = shortToken;
         tdToken.title = fullToken;
+        const tdDroplets = document.createElement('td');
+        const dropletsRaw = (row.droplets == null ? null : Number(row.droplets));
+        const droplets = (Number.isFinite(dropletsRaw) ? Math.floor(dropletsRaw) : null);
+        tdDroplets.textContent = droplets == null ? '-' : String(droplets);
         const tdPixel = document.createElement('td');
         const countRaw = (row.pixelCount == null ? null : Number(row.pixelCount));
         const maxRaw = (row.pixelMax == null ? null : Number(row.pixelMax));
@@ -3159,6 +3164,7 @@
         tdActions.appendChild(actionsWrap);
         tr.appendChild(tdName);
         tr.appendChild(tdToken);
+        tr.appendChild(tdDroplets);
         tr.appendChild(tdPixel);
         tr.appendChild(tdStatus);
         tr.appendChild(tdActions);


### PR DESCRIPTION
- show droplets in accounts table

- add requestPurchase helper and /api/purchase route for authenticated droplet buys

- enable UI buttons for “+5 max charges” and “+30 paint charges” (500 droplets each)

- refresh account data and show success/error toasts after a purchase

- update translations and adjust button layout to preserve table design