### PR TITLE
Feature: auto buy for premium colors

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,6 +98,7 @@ const DB_DIR = path.resolve(process.cwd(), 'db');
 const ACCOUNTS_FILE = path.join(DB_DIR, 'accounts.json');
 const SETTINGS_FILE = path.join(DB_DIR, 'settings.json');
 const FAVORITES_FILE = path.join(DB_DIR, 'favorites.json');
+const COLOR_STATS_FILE = path.join(DB_DIR, 'colorStats.json');
 
 function ensureDb() {
   try { fs.mkdirSync(DB_DIR, { recursive: true }); } catch {}
@@ -109,6 +110,9 @@ function ensureDb() {
   }
   if (!fs.existsSync(FAVORITES_FILE)) {
     try { fs.writeFileSync(FAVORITES_FILE, JSON.stringify([], null, 2)); } catch {}
+  }
+  if (!fs.existsSync(COLOR_STATS_FILE)) {
+    try { fs.writeFileSync(COLOR_STATS_FILE, JSON.stringify({}, null, 2)); } catch {}
   }
 }
 
@@ -954,31 +958,36 @@ function startServer(port, host) {
           for (let i = 0; i < 32; i++) {
             if (bitmap & (1 << i)) owned.push(i + 32);
           }
-          const missing = [];
+          let missing = [];
           for (let i = 0; i < 32; i++) {
             if (!owned.includes(i + 32)) missing.push(i + 32);
           }
           
-          const price = 2000;
-          let droplets = Number(acct.droplets || 0);
-          const maxPurchases = Math.min(missing.length, Math.floor(droplets / price));
-          const productId = 100;
-          const qty = 1;
-          let total = 0;
-          
-          for (const colorId of missing) {
-            if (total >= maxPurchases) break;
-            try {
-              total++;
-              await purchaseColor(acct.token, productId, qty, colorId);
-              droplets -= price;
-              console.log('Purchased color', colorId, "for account", acct.name); // TODO: Remove
-            } catch (e) {
-              console.error('Purchase failed for', colorId, "for account", acct.name,"Error:", e); // TODO: Remove
+          if (missing.length === 0) {
+            acct.autobuy = "max";
+          } else {
+            const price = 2000;
+            let droplets = Number(acct.droplets || 0);
+            const maxPurchases = Math.min(missing.length, Math.floor(droplets / price));
+            const productId = 100;
+            const qty = 1;
+            let total = 0;
+            missing = getColorsSortedByRarity(missing);
+            for (const colorId of missing) {
+              if (total >= maxPurchases) break;
+              try {
+                total++;
+                await purchaseColor(acct.token, productId, qty, colorId);
+                droplets -= price;
+                console.log('Purchased color', colorId, "for account", acct.name); // TODO: Remove
+              } catch (e) {
+                console.error('Purchase failed for', colorId, "for account", acct.name,"Error:", e); // TODO: Remove
+              }
             }
           }
         }
         accounts[idx] = acct;
+        updateColorStats(accounts);
         writeJson(ACCOUNTS_FILE, accounts);
         res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
         res.end(JSON.stringify(acct));
@@ -1014,6 +1023,29 @@ function startServer(port, host) {
     console.log(`Listening on http://${host}:${port}`);
   });
 }
+
+function updateColorStats(accounts) {
+  const colorUsage = {};
+  for (const acct of accounts) {
+    const bitmap = acct.extraColorsBitmap || 0;
+    for (let i = 0; i < 32; i++) {
+      if (bitmap & (1 << i)) {
+        const colorId = i + 32;
+        colorUsage[colorId] = (colorUsage[colorId] || 0) + 1;
+      }
+    }
+  }
+  writeJson(COLOR_STATS_FILE, colorUsage);
+}
+
+function getColorsSortedByRarity(missing) {
+  const stats = readJson(COLOR_STATS_FILE, {});
+  const arr = missing.map((colorId) => {
+    const count = stats.hasOwnProperty(colorId) ? stats[colorId] : 0;
+    return { colorId, count };
+  });
+  arr.sort((a, b) => a.count - b.count);
+  return arr.map(x => x.colorId);}
 
 function main() {
   const args = process.argv.slice(2);

--- a/main.js
+++ b/main.js
@@ -1031,7 +1031,7 @@ function updateColorStats(accounts) {
     for (let i = 0; i < 32; i++) {
       if (bitmap & (1 << i)) {
         const colorId = i + 32;
-        colorUsage[colorId] = (colorUsage[colorId] || 0) + 1;
+        colorUsage[colorId] = (colorUsage[colorId] || 0) + (acct.pixelMax || 0);
       }
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -961,6 +961,10 @@
               <div class="shop-desc" style="margin-top:8px;" data-i18n="shop.exclusive">Exclusive palette</div>
               <div id="shop-premium-palette" class="shop-palette-grid" aria-label="Premium color palette"></div>
               <div id="shop-premium-buy" class="shop-pill" role="button" tabindex="0" data-i18n="shop.buyPremium">💧 2000 Droplets</div>
+              <div class="shop-auto-wrap">
+                <span class="select-mode-label" data-i18n="shop.autoBuy">Auto-buy</span>
+                <button class="select-mode-track" id="shop-premium-auto" type="button" role="switch" aria-checked="false" aria-label="Auto-buy"><span class="select-mode-knob"></span></button>
+              </div>
             </div>
           </div>
         </div>
@@ -1929,6 +1933,7 @@
     const shopRecPriceEl = document.getElementById('shop-rec-price');
     const shopMaxAutoBtn = document.getElementById('shop-max-auto');
     const shopRecAutoBtn = document.getElementById('shop-rec-auto');
+    const shopPremiumAutoBtn = document.getElementById('shop-premium-auto');
     const shopPremiumPaletteWrap = document.getElementById('shop-premium-palette');
     const shopPremiumOwnedWrap = document.getElementById('shop-premium-owned');
     const shopPremiumBuyBtn = document.getElementById('shop-premium-buy');
@@ -5440,6 +5445,11 @@ function loadImage(area, no, preserveView = false) {
           shopRecAutoBtn.setAttribute('aria-checked', onRec ? 'true' : 'false');
           shopRecAutoBtn.classList.toggle('on', onRec);
         }
+        const onPremium = val === 'premium';
+        if (shopPremiumAutoBtn) {
+          shopPremiumAutoBtn.setAttribute('aria-checked', onPremium ? 'true' : 'false');
+          shopPremiumAutoBtn.classList.toggle('on', onPremium);
+        }
       } catch {}
     }
 
@@ -5464,6 +5474,8 @@ function loadImage(area, no, preserveView = false) {
     }
 
     // Wire buttons
+    if (shopPremiumAutoBtn) shopPremiumAutoBtn.addEventListener('click', () => toggleAutobuy('premium'));
+
     if (shopMaxDecBtn) shopMaxDecBtn.addEventListener('click', () => changeQty('max', -1));
     if (shopMaxIncBtn) shopMaxIncBtn.addEventListener('click', () => changeQty('max', +1));
     if (shopMaxMaxBtn) shopMaxMaxBtn.addEventListener('click', () => setMaxAffordable('max'));


### PR DESCRIPTION
Add auto-buy feature for premium palette in shop
- Introduced a toggle button for auto-buying the premium palette.
- Updated the UI to include a label and button for the auto-buy feature.
- Enhanced event handling to manage the state of the auto-buy toggle.
- Prioritizes premium colors based on number of accounts with that color
- Automatically switches back to max when all colors are purchased 

<img width="992" height="601" alt="image" src="https://github.com/user-attachments/assets/739bec1f-2771-4e34-83bc-36ad1385fad0" />
