### PR TITLE
Feature: Add download icon to images

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3257,6 +3257,15 @@
       '0110110',
       '0111110'
     ];
+    const PIX_ICON_DOWNLOAD = [
+      '0001000',
+      '0001000',
+      '0001000',
+      '1001001',
+      '0101010',
+      '0011100',
+      '0001000'
+    ];
     const PIX_ICON_X = [
       '1000001',
       '0100010',
@@ -3439,12 +3448,14 @@
         const lockPattern = sel.locked ? PIX_ICON_LOCK_CLOSED : PIX_ICON_LOCK_OPEN;
         const lockSize = measurePixelIcon(lockPattern, pixelSize);
         const delSize = measurePixelIcon(PIX_ICON_X, pixelSize);
+        const downloadSize = measurePixelIcon(PIX_ICON_DOWNLOAD, pixelSize);
         const showResize = !(sel.locked || sel.lockedByReady);
         const resizeSize = showResize ? measurePixelIcon(PIX_ICON_RESIZE, pixelSize) : { width: 0, height: 0 };
         const lockBgW = lockSize.width + padding * 2;
         const delBgW = delSize.width + padding * 2;
-        const bgH = Math.max(lockSize.height, delSize.height) + padding * 2;
-        const totalW = lockBgW + delBgW + gap;
+        const downloadBgW = downloadSize.width + padding * 2;
+        const bgH = Math.max(lockSize.height, delSize.height, downloadSize.height) + padding * 2;
+        const totalW = lockBgW + delBgW + downloadBgW + gap * 2;
         let xRight = wx0 + iwSel2 - off - totalW;
         let yTop = wy0 + off;
 
@@ -3452,8 +3463,10 @@
         ctx.fillStyle = 'rgba(0,0,0,0.6)';
         const xLockBg = xRight;
         const xDelBg = xLockBg + lockBgW + gap;
+        const xDownloadBg = xDelBg + delBgW + gap;
         ctx.fillRect(xLockBg, yTop, lockBgW, bgH);
         ctx.fillRect(xDelBg, yTop, delBgW, bgH);
+        ctx.fillRect(xDownloadBg, yTop, downloadBgW, bgH);
         let resizeBgW, resizeBgH, xResizeBg, yResizeBg, xResizeIcon, yResizeIcon;
         if (showResize) {
           resizeBgW = resizeSize.width + padding * 2;
@@ -3470,6 +3483,9 @@
         const xDelIcon = xDelBg + padding;
         drawPixelIcon(ctx, PIX_ICON_X, xDelIcon, yIcons, pixelSize, '#ffffff');
 
+        const xDownloadIcon = xDownloadBg + padding;
+        drawPixelIcon(ctx, PIX_ICON_DOWNLOAD, xDownloadIcon, yIcons, pixelSize, '#ffffff');
+
         if (showResize) {
           xResizeIcon = xResizeBg + padding;
           yResizeIcon = yResizeBg + padding;
@@ -3480,6 +3496,7 @@
         sel._overlayRects = {
           lock: { x: xLockIcon, y: yIcons, w: lockSize.width, h: lockSize.height },
           del: { x: xDelIcon, y: yIcons, w: delSize.width, h: delSize.height },
+          download: { x: xDownloadIcon, y: yIcons, w: downloadSize.width, h: downloadSize.height },
           resize: showResize ? { x: xResizeBg, y: yResizeBg, w: resizeBgW, h: resizeBgH } : null,
           bg: { x: xRight, y: yTop, w: totalW, h: bgH }
         };
@@ -4050,6 +4067,7 @@ function loadImage(area, no, preserveView = false) {
           if (rbg && worldX >= rbg.x && worldX <= rbg.x + rbg.w && worldY >= rbg.y && worldY <= rbg.y + rbg.h) {
             const rLock = it._overlayRects.lock;
             const rDel = it._overlayRects.del;
+            const rDownload = it._overlayRects.download;
             if (rLock && worldX >= rLock.x && worldX <= rLock.x + rLock.w && worldY >= rLock.y && worldY <= rLock.y + rLock.h) {
               it.locked = !it.locked;
               try { updateItemLockUi(it); } catch {}
@@ -4072,6 +4090,16 @@ function loadImage(area, no, preserveView = false) {
               deleteItem(it);
               render();
               return;
+            }
+            if (rDownload && worldX >= rDownload.x && worldX <= rDownload.x + rDownload.w && worldY >= rDownload.y && worldY <= rDownload.y + rDownload.h) {
+              try {
+                const a = document.createElement('a');
+                a.href = it.dataUrl || it.url;
+                a.download = it.fileName || 'image.png';
+                a.click();
+              } catch (e) {
+                console.error("Download failed: ", e);
+              }
             }
           }
           const rResize = it._overlayRects.resize;


### PR DESCRIPTION
For every image, there will be a download button that lets you download the converted image.

<img width="1103" height="512" alt="image" src="https://github.com/user-attachments/assets/55922451-c032-47f1-9cc2-5360875716ae" />

Closes #131